### PR TITLE
Expanded DropPath Functionality and a libreoffice fix

### DIFF
--- a/choco-remixer/pkgs/PkgFunctions-install.ps1
+++ b/choco-remixer/pkgs/PkgFunctions-install.ps1
@@ -200,7 +200,10 @@ Function Convert-libreoffice-fresh ($obj) {
     $filePath64 = 'file64   = (Join-Path $toolsDir "' + $filename64 + '")'
 
     if (-not (IsUrlValid $url32)) {
+        # line with     version  =  'x.y.z'
         $officeVersion = ($obj.installScriptOrig -split "`n" | Select-String -Pattern ' version ').tostring()
+        $officeVersion = ($OfficeVersion -split "=" | Select-Object -Last 1).tostring()
+        $officeVersion = ($officeVersion -replace "'","").Trim()
         $exactVersion = GetLibOExactVersion $officeVersion
         $url32 = $exactVersion.Url32
         $url64 = $exactVersion.Url64
@@ -235,7 +238,10 @@ Function Convert-libreoffice-still ($obj) {
     $filePath64 = 'file64   = (Join-Path $toolsDir "' + $filename64 + '")'
 
     if (-not (IsUrlValid $url32)) {
+        # line with     version  =  'x.y.z'
         $officeVersion = ($obj.installScriptOrig -split "`n" | Select-String -Pattern ' version ').tostring()
+        $officeVersion = ($OfficeVersion -split "=" | Select-Object -Last 1).tostring()
+        $officeVersion = ($officeVersion -replace "'","").Trim()
         $exactVersion = GetLibOExactVersion $officeVersion
         $url32 = $exactVersion.Url32
         $url64 = $exactVersion.Url64

--- a/choco-remixer/private/Get-RemixerConfig.ps1
+++ b/choco-remixer/private/Get-RemixerConfig.ps1
@@ -146,7 +146,17 @@
     $config.workDir = (Resolve-Path $config.workDir).Path
 
     if ($config.useDropPath -eq "yes") {
-        Test-DropPath -dropPath $config.dropPath
+        if ($config.dropEmpty -eq "yes") {
+        } elseif ($config.dropEmpty -eq "no") {
+        } else {
+            Throw "bad dropEmpty value in config xml, must be yes or no"
+        }
+        if ($config.dropInternal -eq "yes") {
+        } elseif ($config.dropInternal -eq "no") {
+        } else {
+            Throw "bad dropInternal value in config xml, must be yes or no"
+        }
+        Test-DropPath -dropPath $config.dropPath -dropEmpty $config.dropEmpty
         $config.dropPath = (Resolve-Path $config.dropPath).Path
     } elseif ($config.useDropPath -eq "no") {
     } else {

--- a/choco-remixer/private/Test-DropPath.ps1
+++ b/choco-remixer/private/Test-DropPath.ps1
@@ -1,14 +1,21 @@
-﻿Function Test-DropPath ($dropPath) {
+﻿Function Test-DropPath {
+    param (
+        [parameter(Mandatory = $true)][string]$dropPath,
+        [parameter(Mandatory = $true)][string]$dropEmpty
+    )
+
     if (!(Test-Path $dropPath)) {
         Throw "Drop path not found, please specify valid path"
     }
 
-    for (($i = 0); ($i -le 12) -and ($null -ne $(Get-ChildItem -Path $dropPath -Filter "*.nupkg")) ; $i++ ) {
-        Write-Output "Found files in the drop path, waiting 15 seconds for them to clear"
-        Start-Sleep -Seconds 15
-    }
+    if ($dropEmpty -eq 'yes') {
+        for (($i = 0); ($i -le 12) -and ($null -ne $(Get-ChildItem -Path $dropPath -Filter "*.nupkg")) ; $i++ ) {
+            Write-Output "Found files in the drop path, waiting 15 seconds for them to clear"
+            Start-Sleep -Seconds 15
+        }
 
-    if ($null -ne $(Get-ChildItem -Path $dropPath -Filter "*.nupkg")) {
-        Write-Warning "There are still files in the drop path"
+        if ($null -ne $(Get-ChildItem -Path $dropPath -Filter "*.nupkg")) {
+            Write-Warning "There are still files in the drop path"
+        }
     }
 }

--- a/choco-remixer/public/Invoke-InternalizeChocoPkg.ps1
+++ b/choco-remixer/public/Invoke-InternalizeChocoPkg.ps1
@@ -98,6 +98,14 @@ Function Invoke-InternalizeChocoPkg {
             Write-Verbose "$nuspecID is a custom package"
         } elseif ($packagesXMLcontent.packages.internal.id -icontains $nuspecID) {
             Write-Verbose "$nuspecID is already internal coming from chocolatey.org"
+            #quick and dirty, maybe keep already interal packages in list and process (skip and maybe drop) later
+            if ($config.useDropPath -eq "yes" -and $config.dropInternal -eq "yes") {
+                Write-Verbose "coping $.nuspecID) to drop path"
+                if (-not (Test-Path (Join-Path -Path $config.dropPath -ChildPath (Split-Path $_.FullName -Leaf) ))) {
+                    Copy-Item $_.fullname $config.dropPath
+                }
+            }
+
         } elseif ($packagesXMLcontent.packages.custom.pkg.id -icontains $nuspecID) {
 
             $installScriptDetails = Read-ZippedInstallScript -NupkgPath $_.fullname

--- a/config.xml.template
+++ b/config.xml.template
@@ -10,6 +10,11 @@
 	<useDropPath>no</useDropPath>
 	<!-- Directory that is your ProGet drop path -->
 	<dropPath>C:\path\to\droppath</dropPath>
+	<!-- Yes/No if directory should be empty -->
+	<dropEmpty>no</dropEmpty>
+	<!-- Yes/No if internal packages should be dropped -->
+	<dropInternal>yes</dropInternal>
+
 
 	<!-- Yes/No to automatically filling out internalized package versions -->
 	<writePerPkgs>yes</writePerPkgs>


### PR DESCRIPTION
Expanded the drop path functionality (check for empty / copying internal)  --> all internal and "remixed" packages are copied to the drop path

Fixed a issue in libreoffice-fresh/still 

Please have a look at my choco-psmodule-remixer repo. Download powershell modules from the PSGallery and packaging them (with a template) as choco packages. 