### PR TITLE
Both architectures (x86 and x64)

### DIFF
--- a/choco-remixer/pkgs/PkgFunctions-standard.ps1
+++ b/choco-remixer/pkgs/PkgFunctions-standard.ps1
@@ -1575,7 +1575,7 @@ Function Convert-jabref-install ([PackageInternalizeInfo]$obj) {
 
 Function Convert-pdf24 ([PackageInternalizeInfo]$obj) {
     $editInstallChocolateyPackageArgs = @{
-        architecture     = "x32"
+        architecture     = "both"
         nuspecID         = $obj.nuspecID
         version          = $obj.version
         installScript    = $obj.installScriptOrig


### PR DESCRIPTION
Add x64 for pdf24. Verified with Windows 10 22H2.