### PR TITLE
support Uppercase Tools Directory

### DIFF
--- a/choco-remixer/public/Invoke-InternalizeDownloadedChocoPkg.ps1
+++ b/choco-remixer/public/Invoke-InternalizeDownloadedChocoPkg.ps1
@@ -137,6 +137,14 @@ Function Invoke-InternalizeDownloadedChocoPkg {
     Expand-Nupkg -Path $obj.OrigPath -Destination $obj.VersionDir -NoAddFilesElement
 
     $failed = $false
+    if( ! (Test-Path $obj.toolsDir)){
+        Write-Information "$($obj.toolsDir) does not exists, trying to use the Uppercase Version" -InformationAction Continue
+        $newToolsDir = (Join-Path $obj.versionDir "Tools")
+        if(Test-Path $newToolsDir){
+            $obj.toolsDir = $newToolsDir
+            Write-Information "Uppercase Version $($obj.toolsDir) found" -InformationAction Continue
+        }
+    }
     Try {
         & $obj.functionName -obj $obj
     } Catch {


### PR DESCRIPTION
Some Packages like KB3033929 use an Uppercase Tools directory.
This is a Problem on Case Sensitive Filesystem like ext4 on Linux.