### PR TITLE
windirstat is no longer internalized

### DIFF
--- a/choco-remixer/pkgs/packages.xml
+++ b/choco-remixer/pkgs/packages.xml
@@ -3348,7 +3348,6 @@
     <id>wincdemu</id>
     <id>wincompose</id>
     <id>wincvt</id>
-    <id>windirstat</id>
     <id>windowinspector</id>
     <id>windows-11-installation-assistant</id>
     <id>windows-adk-oscdimg</id>
@@ -25044,6 +25043,19 @@
       <argsType>0</argsType>
       <removeEXE>yes</removeEXE>
       <checksumArgsType>5</checksumArgsType>
+      <checksumTypeType>sha256</checksumTypeType>
+      <whyNotInternal>ToDetermine</whyNotInternal>
+    </pkg>
+    <pkg>
+      <id>windirstat</id>
+      <functionName>Convert-InstallChocolateyPackage</functionName>
+      <needsStopAction>no</needsStopAction>
+      <needsToolsDir>yes</needsToolsDir>
+      <architecture>both</architecture>
+      <urlType>2</urlType>
+      <argsType>0</argsType>
+      <removeMSI>yes</removeMSI>
+      <checksumArgsType>0</checksumArgsType>
       <checksumTypeType>sha256</checksumTypeType>
       <whyNotInternal>ToDetermine</whyNotInternal>
     </pkg>


### PR DESCRIPTION
The last choco version of windirstat to have the exe included was 1.1.2 (2016)
https://community.chocolatey.org/packages/windirstat/1.1.2.20161210#files

Starting 2.1.1 (December 8, 2024) the chocolatey package did not include a exe or msi.
